### PR TITLE
n_jobs put to -2 for stability issues

### DIFF
--- a/TinyAutoML/Models/EstimatorsPool.py
+++ b/TinyAutoML/Models/EstimatorsPool.py
@@ -41,7 +41,7 @@ class EstimatorPool(BaseEstimator):
             if estimator[0] in estimators_params:
                 clf = RandomizedSearchCV(estimator=estimator[1],
                                          param_distributions=estimators_params[estimator[0]], scoring=metrics,
-                                         n_jobs=-1, cv=cv)
+                                         n_jobs=-2, cv=cv)
                 clf.fit(X, y)
 
                 estimator[1].set_params(**clf.best_params_)

--- a/TinyAutoML/Models/EstimatorsPoolCV.py
+++ b/TinyAutoML/Models/EstimatorsPoolCV.py
@@ -48,7 +48,7 @@ class EstimatorPoolCV(BaseEstimator):
                 grid = {f'{estimator[1].__repr__()}__{key}': value for key, value in estimators_params[estimator[0]].items()}
                 clf = RandomizedSearchCV(estimator=pipe,
                                          param_distributions=grid, scoring=metrics,
-                                         n_jobs=-1, cv=cv, verbose=1)
+                                         n_jobs=-2, cv=cv, verbose=1)
                 clf.fit(X, y)
 
                 pipe.set_params(**clf.best_params_)

--- a/TinyAutoML/Models/OneRulerForAll.py
+++ b/TinyAutoML/Models/OneRulerForAll.py
@@ -53,7 +53,7 @@ class OneRulerForAll(BaseEstimator):
         if self.rulerName in estimators_params:
             clf = RandomizedSearchCV(estimator=RandomForestClassifier(),
                                      param_distributions=estimators_params[self.rulerName], scoring=self.metrics,
-                                     n_jobs=-1, cv=cv)
+                                     n_jobs=-2, cv=cv)
             clf.fit(estimatorsPoolOutputs, y)
             self.ruler.set_params(**clf.best_params_)
         self.ruler.fit(estimatorsPoolOutputs, y)


### PR DESCRIPTION
n_jobs = -1 causes stability issues (puts max RAM on all cores, can crash if CPU spikes due to other apps)
n_jobs = -2 leaves one core free to handle other apps