### PR TITLE
Pre-processing revamp

### DIFF
--- a/TinyAutoML/MetaPipeline.py
+++ b/TinyAutoML/MetaPipeline.py
@@ -45,7 +45,7 @@ class MetaPipeline(BaseEstimator, ClassifierMixin, TransformerMixin):
         self.estimator = (
             self.model
             if self.model.comprehensiveSearch
-            else buildMetaPipeline(X, self.model)
+            else buildMetaPipeline(self.model)
         )
 
         if pool is not None and self.model.comprehensiveSearch:
@@ -58,7 +58,7 @@ class MetaPipeline(BaseEstimator, ClassifierMixin, TransformerMixin):
             X = pd.DataFrame(
                 pool.transform(X),  # type: ignore
                 columns=self.estimator.named_steps[  # type: ignore
-                    "Lasso Selector"
+                    "feature_selection"
                 ].selectedFeaturesNames,
             )
 

--- a/TinyAutoML/Models/EstimatorPools/EstimatorPool.py
+++ b/TinyAutoML/Models/EstimatorPools/EstimatorPool.py
@@ -25,7 +25,7 @@ class EstimatorPool:
             ("Logistic Regression", LogisticRegression(fit_intercept=True)),
             ("Gaussian Naive Bayes", GaussianNB()),
             ("LDA", LinearDiscriminantAnalysis()),
-            ("xgb", XGBClassifier(use_label_encoder=False, eval_metric="logloss")),
+            ("xgb", XGBClassifier(eval_metric="logloss")),
         ]
 
         self.is_fitted = False

--- a/TinyAutoML/Models/EstimatorPools/EstimatorPoolCV.py
+++ b/TinyAutoML/Models/EstimatorPools/EstimatorPoolCV.py
@@ -37,7 +37,7 @@ class EstimatorPoolCV:
         self, X: pd.DataFrame, y: pd.Series, **kwargs
     ) -> List[tuple[str, Pipeline]]:
         self.estimatorsPipeline = [
-            (estimator_name, buildMetaPipeline(X, estimator).fit(X, y, **kwargs))
+            (estimator_name, buildMetaPipeline(estimator).fit(X, y, **kwargs))
             for estimator_name, estimator in self.estimatorsList
         ]
         self.is_fitted = True
@@ -53,7 +53,7 @@ class EstimatorPoolCV:
     ) -> List[tuple[str, Pipeline]]:
 
         for estimator in tqdm(self.estimatorsList):
-            pipe = buildMetaPipeline(X, estimator=estimator[1])
+            pipe = buildMetaPipeline(estimator=estimator[1])
             if estimator[0] in estimators_params:
                 grid = {
                     f"{estimator[1].__repr__()}__{key}": value

--- a/TinyAutoML/Preprocessing/LabeledOneHotEncoder.py
+++ b/TinyAutoML/Preprocessing/LabeledOneHotEncoder.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+
+class LabeledOneHotEncoder(BaseEstimator, TransformerMixin):
+    """
+    Custom One-Hot Encoder for pandas DataFrame or numpy array.
+
+    This encoder transforms categorical columns into one-hot encoded columns,
+    while preserving the continuous columns. It provides labeled column names
+    for the new categorical columns in the form of feature_I.
+
+    Parameters:
+    -----------
+    None
+
+    Attributes:
+    -----------
+    columns : array-like
+        The column names of the original DataFrame or feature names of the array.
+    cat_columns : array-like
+        The column names or feature names of the categorical columns.
+    continuous_columns : array-like
+        The column names or feature names of the continuous columns.
+    categories_ : dict
+        A dictionary containing unique categories for each categorical column.
+
+    Methods:
+    --------
+    fit(X)
+        Fit the encoder to the input DataFrame or array and store necessary attributes.
+        Returns the encoder object.
+    transform(X)
+        Transform the input DataFrame or array by one-hot encoding categorical columns
+        and concatenating with continuous columns. Returns the transformed DataFrame.
+    """
+
+    def __init__(self):
+        self.columns = None
+        self.cat_columns = None
+        self.continuous_columns = None
+        self.categories_ = None
+
+    def fit(self, X, y=None):
+        """
+        Fit the encoder to the input DataFrame or array.
+
+        Parameters:
+        -----------
+        X : pandas DataFrame or numpy array, shape (n_samples, n_features)
+            The input DataFrame or array to fit the encoder.
+
+        Returns:
+        --------
+        self : LabeledOneHotEncoder
+            The fitted encoder object.
+        """
+        if isinstance(X, pd.DataFrame):
+            self.columns = X.columns
+            self.cat_columns = X.select_dtypes(include=['object', 'category']).columns
+            self.continuous_columns = X.select_dtypes(exclude=['object', 'category']).columns
+            self.categories_ = {col: X[col].unique() for col in self.cat_columns}
+        elif isinstance(X, np.ndarray):
+            n_features = X.shape[1]
+            self.columns = [f"feature_{i}" for i in range(n_features)]
+            self.cat_columns = np.arange(n_features)
+            self.continuous_columns = []
+            self.categories_ = {i: np.unique(X[:, i]) for i in range(n_features)}
+        else:
+            raise ValueError("Input must be a pandas DataFrame or numpy array.")
+
+        return self
+
+    def transform(self, X, y=None):
+        """
+        Transform the input DataFrame or array by one-hot encoding categorical columns
+        and concatenating with continuous columns.
+
+        Parameters:
+        -----------
+        X : pandas DataFrame or numpy array, shape (n_samples, n_features)
+            The input DataFrame or array to transform.
+
+        Returns:
+        --------
+        X_transformed : pandas DataFrame, shape (n_samples, n_features_transformed)
+            The transformed DataFrame with one-hot encoded categorical columns
+            and continuous columns.
+        """
+        
+        if isinstance(X, pd.DataFrame):
+            X_cont = X[self.continuous_columns]
+
+            if self.cat_columns.any():
+                X_cat = pd.get_dummies(X[self.cat_columns], prefix=self.cat_columns)
+                X_transformed = pd.concat([X_cont, X_cat], axis=1)
+            else:
+                X_transformed = X_cont
+        elif isinstance(X, np.ndarray):
+            X_cont = np.delete(X, self.cat_columns, axis=1)
+
+            if self.cat_columns.any():
+                X_cat = np.concatenate([pd.get_dummies(X[:, i], prefix=f"feature_{i}") for i in self.cat_columns], axis=1)
+                X_transformed = np.concatenate((X_cont, X_cat), axis=1)
+                X_transformed = pd.DataFrame(X_transformed, columns=self.columns)
+            else:
+                X_transformed = pd.DataFrame(X_cont, columns=self.columns)
+        else:
+            raise ValueError("Input must be a pandas DataFrame or numpy array.")
+            
+        return X_transformed

--- a/TinyAutoML/Preprocessing/NonStationarityCorrector.py
+++ b/TinyAutoML/Preprocessing/NonStationarityCorrector.py
@@ -98,6 +98,9 @@ class NonStationarityCorrector(BaseEstimator, TransformerMixin):
 
         if X.shape[0] > WINDOW:
             for col in self.colsToCorrect:
+                # Depending on the window size, std can be null.
+                # In that situation the actual value can be replaced by the last non null value
+                # We also use loc[start+WINDOW:] in order to leave the WINDOW first rows intact. Otherwise, it would be nans
                 X[col].iloc[WINDOW:] = (
                     (X[col] - X[col].rolling(window=WINDOW).mean())
                     / X[col]

--- a/TinyAutoML/Preprocessing/NonStationarityCorrector.py
+++ b/TinyAutoML/Preprocessing/NonStationarityCorrector.py
@@ -89,7 +89,6 @@ class NonStationarityCorrector(BaseEstimator, TransformerMixin):
         X : pd.DataFrame
             DataFrame with corrected columns.
         """
-        print(X)
         if not self.indexedByTime:
             return X
         

--- a/TinyAutoML/Preprocessing/NonStationarityCorrector.py
+++ b/TinyAutoML/Preprocessing/NonStationarityCorrector.py
@@ -1,35 +1,67 @@
-import logging
 import pandas as pd
-
+import logging
 from statsmodels.tsa.stattools import adfuller
 from sklearn.preprocessing import StandardScaler
 from sklearn.base import BaseEstimator, TransformerMixin
+from pandas.api.types import is_numeric_dtype, is_datetime64_any_dtype
 
 from ..constants.GLOBAL_PARAMS import WINDOW
+from ..support.MyTools import isIndexedByTime
 
 pd.options.mode.chained_assignment = None  # default='warn'
 
 
 class NonStationarityCorrector(BaseEstimator, TransformerMixin):
     """
-    Correct columns that don't seem stationary according to Augmented Dicker Fuller statistical stationarity test
+    Correct columns that don't seem stationary according to Augmented Dicker Fuller statistical stationarity test.
+
+    Parameters
+    ----------
+    colsToKeepIntact : list, optional
+        List of columns that should not be corrected even if they are found non-stationary.
+
+    Attributes
+    ----------
+    colsToCorrect : list
+        List of columns that need to be corrected for stationarity.
     """
 
     def __init__(self, colsToKeepIntact=None):
-        # If the user wants some columns to remain intact, they can be passed as arguments
         if colsToKeepIntact is None:
             colsToKeepIntact = []
         self.colsToKeepIntact = colsToKeepIntact
         self.colsToCorrect = []
+        self.indexedByTime = False
 
-    def fit(self, X: pd.DataFrame, y: pd.Series) -> TransformerMixin:
+    def fit(self, X: pd.DataFrame, y=None) -> TransformerMixin:
         """
-        split the cols according to Augmented Dicker Fuller statistical stationarity test
+        Identify the columns in the DataFrame that need stationarity correction.
+
+        The Augmented Dickey-Fuller test is applied to each numeric column in the DataFrame. Columns with p-values above 0.05 are considered non-stationary and are marked for correction. This method also checks whether the DataFrame index is of type datetime and logs a warning if it is not.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Input DataFrame.
+        y : pd.Series
+            Target values.
+
+        Returns
+        -------
+        self : TransformerMixin
         """
+        
+        self.indexedByTime = isIndexedByTime(X)
+        # Check if the DataFrame is time-indexed
+        if not self.indexedByTime:
+            logging.info("Index is not datetime. Stationarity correction was skipped.")
+            return self
+
+        # Identify columns to correct
         for col in X.columns:
-            if col not in self.colsToKeepIntact:
+            if col not in self.colsToKeepIntact and is_numeric_dtype(X[col]):
                 p_val = adfuller(X[col].values)[1]
-                if p_val > 0.05: #Test à 5%
+                if p_val > 0.05:  # 5% test
                     self.colsToCorrect.append(col)
                 else:
                     self.colsToKeepIntact.append(col)
@@ -40,23 +72,39 @@ class NonStationarityCorrector(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X: pd.DataFrame, y=None) -> pd.DataFrame:
-        # Apply the transformations
+        """
+        Apply stationarity correction to the identified columns in the DataFrame.
+
+        For each column marked for correction, the rolling mean and standard deviation are calculated and used to correct the column values. If the DataFrame has fewer rows than the window size, all columns in the DataFrame are standardized instead. This method also standardizes columns that are marked to be kept intact.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Input DataFrame.
+        y : None
+            Not used. Included for compatibility with scikit-learn Transformer API.
+
+        Returns
+        -------
+        X : pd.DataFrame
+            DataFrame with corrected columns.
+        """
+        print(X)
+        if not self.indexedByTime:
+            return X
+        
         X = X.copy()
         logging.debug("Correcting non-stationarity on the dataset...")
+
         if X.shape[0] > WINDOW:
             for col in self.colsToCorrect:
-                # Depending on the window size, std can be null.
-                # In that situation the actual value can be replaced by the last non null value
-                # We also use loc[start+WINDOW:] in order to leave the WINDOW first rows intact. Otherwise, it would be nans
-                X[col].iloc[WINDOW:] = (  # type: ignore
+                X[col].iloc[WINDOW:] = (
                     (X[col] - X[col].rolling(window=WINDOW).mean())
                     / X[col]
                     .rolling(window=WINDOW)
                     .std(skipna=True)
                     .replace(to_replace=0.0, method="ffill")
-                ).iloc[
-                    WINDOW:
-                ]  # type: ignore
+                ).iloc[WINDOW:]
 
             if self.colsToKeepIntact:
                 X[self.colsToKeepIntact] = StandardScaler().fit_transform(
@@ -64,6 +112,6 @@ class NonStationarityCorrector(BaseEstimator, TransformerMixin):
                 )
         else:
             X[X.columns] = StandardScaler().fit_transform(X[X.columns])
-            assert type(X) == pd.DataFrame, "type error"
+            assert isinstance(X, pd.DataFrame), "type error"
 
         return X

--- a/TinyAutoML/support/MyTools.py
+++ b/TinyAutoML/support/MyTools.py
@@ -58,21 +58,20 @@ def get_df_scaler(scaler):
         def __init__(self):
             self.scaler = scaler
             self.columns = None  # Array to store input DataFrame column names
-            self.index = None
 
         def fit(self, X, y=None):
             # Handle the case when X is a DataFrame
             if isinstance(X, pd.DataFrame):
                 self.columns = X.columns
-                self.index = X.index
             self.scaler.fit(X, y)
             return self
 
         def transform(self, X, y=None):
             check_is_fitted(self.scaler)
             X_scaled = self.scaler.transform(X)
+            index = X.index if isinstance(X, pd.DataFrame) else None
             if self.columns is not None and isinstance(X, pd.DataFrame):
-                X_scaled = pd.DataFrame(X_scaled, columns=self.columns, index=self.index)
+                X_scaled = pd.DataFrame(X_scaled, columns=self.columns, index=index)
             return X_scaled
     return DataFrameScaler
 


### PR DESCRIPTION
Refresh to the pre-processing methodology to be more versatile and comprehensive.

In the past, categorical columns were breaking the `buildMetaPipeline` because the number of columns would change in one of its steps due to the OneHotEncoder.

## Added
- `LabeledOneHotEncoder`: OHE that keeps dataframe column labels
- `get_df_scaler`: Takes sk-learn scaler as input and returns a dataframe-compatible scaler

## Changed
- `buildMetaPipeline`: Complete revamp
- `LassoSelectorTransformer`: 
    - Make K a parameter
    - New selection skip tests
- `NonStationarityCorrector`: Now takes in the whole dataframe as input

## Removed
- `buildColumnTransformer`: Unable to keep column headers with ColumnTransformer

## Example with a new dataset

The Titanic dataset has a mix pf categorical and continuous features. 
```python
import pandas as pd
from sklearn.model_selection import train_test_split
from sklearn.impute import SimpleImputer
from TinyAutoML.Models import *
from TinyAutoML import MetaPipeline

# Load the dataset
titanic = pd.read_csv('https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv')

# Feature columns and target variable
feature_columns = ['Pclass', 'Sex', 'Age', 'SibSp', 'Parch', 'Fare', 'Embarked']
target_column = 'Survived'

# Preprocessing: Fill missing values
continuous_imputer = SimpleImputer(strategy='mean')
titanic['Age'] = continuous_imputer.fit_transform(titanic['Age'].values.reshape(-1, 1))
titanic['Fare'] = continuous_imputer.fit_transform(titanic['Fare'].values.reshape(-1, 1))

categorical_imputer = SimpleImputer(strategy='most_frequent')
titanic['Embarked'] = categorical_imputer.fit_transform(titanic['Embarked'].values.reshape(-1, 1))
titanic['Cabin'] = categorical_imputer.fit_transform(titanic['Cabin'].values.reshape(-1, 1))

X = titanic[feature_columns]
y = titanic[target_column]
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)

# Initialize and fit the model
democratic = MetaPipeline(DemocraticModel(comprehensiveSearch=False, parameterTuning=False))
democratic.fit(X_train, y_train)

democratic.classification_report(X_test, y_test)
```

Output:
```
[TinyAutoML] Index is not datetime. Stationarity correction was skipped.
[TinyAutoML] Number of features less than preSelectionSize, skipping pre-selection.
[TinyAutoML] Training models...
              precision    recall  f1-score   support

           0       0.82      0.84      0.83       105
           1       0.76      0.74      0.75        74

    accuracy                           0.80       179
   macro avg       0.79      0.79      0.79       179
weighted avg       0.80      0.80      0.80       179
```